### PR TITLE
Update Rakefile to pull in improvements from Artichoke

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -1,0 +1,16 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "img.shields.io"
+    }
+  ],
+  "replacementPatterns": [],
+  "httpHeaders": [
+    {
+      "urls": ["https://crates.io"],
+      "headers": {
+        "Accept": "text/html"
+      }
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,15 +84,24 @@ tasks by running:
 
 ```console
 $ bundle exec rake --tasks
-rake doc             # Generate Rust API documentation
-rake doc:open        # Generate Rust API documentation and open it in a web browser
-rake lint            # Lint and format
-rake lint:clippy     # Run Clippy
-rake lint:format     # Format sources
-rake lint:rubocop    # Run RuboCop
-rake test            # Run Artichoke unit tests
-rake unicode:build   # Rebuild Rust generated Rust sources from Unicode data
-rake unicode:update  # Update Unicode data
+rake build                        # Build Rust workspace
+rake doc                          # Generate Rust API documentation
+rake doc:open                     # Generate Rust API documentation and open it in a web browser
+rake fmt                          # Format sources
+rake fmt:rust                     # Format Rust sources with rustfmt
+rake fmt:text                     # Format text, YAML, and Markdown sources with prettier
+rake format                       # Format sources
+rake format:rust                  # Format Rust sources with rustfmt
+rake format:text                  # Format text, YAML, and Markdown sources with prettier
+rake lint                         # Lint sources
+rake lint:clippy                  # Lint Rust sources with Clippy
+rake lint:clippy:restriction      # Lint Rust sources with Clippy restriction pass (unenforced lints)
+rake lint:rubocop                 # Run RuboCop
+rake lint:rubocop:auto_correct    # Auto-correct RuboCop offenses
+rake release:markdown_link_check  # Check for broken links in markdown files
+rake test                         # Run Focaccia unit tests
+rake unicode:build                # Rebuild Rust generated Rust sources from Unicode data
+rake unicode:update               # Update Unicode data
 ```
 
 To lint Ruby sources, Focaccia uses

--- a/Rakefile
+++ b/Rakefile
@@ -1,48 +1,97 @@
 # frozen_string_literal: true
 
-require 'fileutils'
 require 'open-uri'
+require 'shellwords'
+require 'rubocop/rake_task'
 
-task default: :lint
+task default: %i[format lint]
 
-desc 'Lint and format'
-task lint: %i[lint:format lint:clippy lint:rubocop]
+desc 'Lint sources'
+task lint: %i[lint:clippy lint:rubocop:auto_correct]
 
 namespace :lint do
-  desc 'Run Clippy'
+  RuboCop::RakeTask.new(:rubocop)
+
+  desc 'Lint Rust sources with Clippy'
   task :clippy do
-    roots = Dir.glob('**/{build,lib,main}.rs')
-    roots.each do |root|
+    FileList['**/{build,lib,main}.rs'].each do |root|
       FileUtils.touch(root)
     end
-    sh 'cargo clippy --workspace --all-targets --all-features'
+    sh 'cargo clippy --workspace --all-features'
   end
 
-  desc 'Run RuboCop'
-  task :rubocop do
-    sh 'rubocop -a'
+  desc 'Lint Rust sources with Clippy restriction pass (unenforced lints)'
+  task :'clippy:restriction' do
+    FileList['**/{build,lib,main}.rs'].each do |root|
+      FileUtils.touch(root)
+    end
+    lints = [
+      'clippy::dbg_macro',
+      'clippy::get_unwrap',
+      'clippy::indexing_slicing',
+      'clippy::panic',
+      'clippy::print_stdout',
+      'clippy::expect_used',
+      'clippy::unwrap_used',
+      'clippy::todo',
+      'clippy::unimplemented',
+      'clippy::unreachable'
+    ]
+    command = ['cargo', 'clippy', '--'] + lints.flat_map { |lint| ['-W', lint] }
+    sh command.shelljoin
   end
+end
 
-  desc 'Format sources'
-  task :format do
+desc 'Format sources'
+task format: %i[format:rust format:text]
+
+namespace :format do
+  desc 'Format Rust sources with rustfmt'
+  task :rust do
     sh 'cargo fmt -- --color=auto'
+  end
+
+  desc 'Format text, YAML, and Markdown sources with prettier'
+  task :text do
     sh "npx prettier --write '**/*'"
   end
 end
 
+desc 'Format sources'
+task fmt: %i[fmt:rust fmt:text]
+
+namespace :fmt do
+  desc 'Format Rust sources with rustfmt'
+  task :rust do
+    sh 'cargo fmt -- --color=auto'
+  end
+
+  desc 'Format text, YAML, and Markdown sources with prettier'
+  task :text do
+    sh "npx prettier --write '**/*'"
+  end
+end
+
+desc 'Build Rust workspace'
+task :build do
+  sh 'cargo build --workspace'
+end
+
 desc 'Generate Rust API documentation'
 task :doc do
-  ENV['RUSTDOCFLAGS'] = '-D warnings'
+  ENV['RUSTFLAGS'] = '-D warnings'
+  ENV['RUSTDOCFLAGS'] = '-D warnings --cfg docsrs'
   sh 'rustup run --install nightly cargo doc --workspace'
 end
 
 desc 'Generate Rust API documentation and open it in a web browser'
 task :'doc:open' do
-  ENV['RUSTDOCFLAGS'] = '-D warnings'
+  ENV['RUSTFLAGS'] = '-D warnings'
+  ENV['RUSTDOCFLAGS'] = '-D warnings --cfg docsrs'
   sh 'rustup run --install nightly cargo doc --workspace --open'
 end
 
-desc 'Run Artichoke unit tests'
+desc 'Run Focaccia unit tests'
 task :test do
   sh 'cargo test --workspace'
 end
@@ -50,7 +99,7 @@ end
 namespace :unicode do
   desc 'Rebuild Rust generated Rust sources from Unicode data'
   task :build do
-    sh 'ruby scripts/gen_case_lookups.rb'
+    ruby 'scripts/gen_case_lookups.rb'
   end
 
   desc 'Update Unicode data'
@@ -61,6 +110,25 @@ namespace :unicode do
           file.write(line)
         end
       end
+    end
+  end
+end
+
+namespace :release do
+  link_check_files = FileList.new('**/*.md') do |f|
+    f.exclude('node_modules/**/*')
+    f.exclude('**/target/**/*')
+    f.exclude('**/vendor/**/*')
+    f.include('*.md')
+    f.include('**/vendor/*.md')
+  end
+
+  link_check_files.sort.uniq.each do |markdown|
+    desc 'Check for broken links in markdown files'
+    task markdown_link_check: markdown do
+      command = ['npx', 'markdown-link-check', '--config', '.github/markdown-link-check.json', markdown]
+      sh command.shelljoin
+      sleep(rand(1..5))
     end
   end
 end


### PR DESCRIPTION
- Add markdown link check task.
- Use ruby pragma to launch unicode build script.
- Set RUSTFLAGS and RUSTDOCFLAGS when building docs.
- Add top-level fmt and format namespaces.
- Use rubocop-provided Rake task.
- Add clippy:restriction lint pass.
- Use FileList API instead of Dir.glob.

Relates to artichoke/artichoke#825.
Relates to artichoke/artichoke#828.