### PR TITLE
Bump crate version to 1.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focaccia"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = "no_std implementation of Unicode case folding comparisons"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@
 //! [`Error`]: https://doc.rust-lang.org/stable/std/error/trait.Error.html
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![doc(html_root_url = "https://docs.rs/focaccia/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/focaccia/1.0.1")]
 
 // Ensure code blocks in README.md compile
 #[cfg(doctest)]


### PR DESCRIPTION
This release adds comments to generated Unicode sources that
contain the Unicode version and information about how and when
they were generated.