### PR TITLE
Use named links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,31 +1,27 @@
 # Contributing to Artichoke – Focaccia
 
-👋 Hi and welcome to [Artichoke](https://github.com/artichoke). Thanks for
-taking the time to contribute! 💪💎🙌
+👋 Hi and welcome to [Artichoke]. Thanks for taking the time to contribute!
+💪💎🙌
 
 Artichoke aspires to be a Ruby 2.6.3-compatible implementation of the Ruby
-programming language.
-[There is lots to do](https://github.com/artichoke/artichoke/issues).
+programming language. [There is lots to do].
 
 Focaccia is used to implement Unicode case comparison routines for the
-[`Symbol`](https://ruby-doc.org/core-2.6.3/Symbol.html) and
-[`String`](https://ruby-doc.org/core-2.6.3/String.html) classes in Artichoke's
-implementation of Ruby Core.
+[`Symbol`] and [`String`] classes in Artichoke's implementation of Ruby Core.
 
 If Artichoke does not run Ruby source code in the same way that MRI does, it is
-a bug and we would appreciate if you
-[filed an issue so we can fix it](https://github.com/artichoke/artichoke/issues/new).
-[File bugs specific to Focaccia in this repository](https://github.com/artichoke/focaccia/issues/new).
+a bug and we would appreciate if you [filed an issue so we can fix it]. [File
+bugs specific to Focaccia in this repository].
 
 If you would like to contribute code to Focaccia 👩‍💻👨‍💻, find an issue that looks
 interesting and leave a comment that you're beginning to investigate. If there
-is no issue, please file one before beginning to work on a PR.
-[Good first issues are labeled `E-easy`](https://github.com/artichoke/focaccia/labels/E-easy).
+is no issue, please file one before beginning to work on a PR. [Good first
+issues are labeled `E-easy`].
 
 ## Discussion
 
-If you'd like to engage in a discussion outside of GitHub, you can
-[join Artichoke's public Discord server](https://discord.gg/QCe2tp2).
+If you'd like to engage in a discussion outside of GitHub, you can [join
+Artichoke's public Discord server].
 
 ## Setup
 
@@ -40,9 +36,8 @@ Rust compiler.
 
 #### Installation
 
-The recommended way to install the Rust toolchain is with
-[rustup](https://rustup.rs/). On macOS, you can install rustup with
-[Homebrew](https://docs.brew.sh/Installation):
+The recommended way to install the Rust toolchain is with [rustup]. On macOS,
+you can install rustup with [Homebrew]:
 
 ```sh
 brew install rustup-init
@@ -76,7 +71,7 @@ cargo build
 
 ### Ruby
 
-Focaccia requires a recent Ruby 2.x and [bundler](https://bundler.io/) 2.x. The
+Focaccia requires a recent Ruby 2.x and [bundler] 2.x. The
 [`.ruby-version`](.ruby-version) file in this repository specifies Ruby 2.6.3.
 
 Focaccia uses [`rake`](Rakefile) as a task runner. You can see the available
@@ -104,8 +99,7 @@ rake unicode:build                # Rebuild Rust generated Rust sources from Uni
 rake unicode:update               # Update Unicode data
 ```
 
-To lint Ruby sources, Focaccia uses
-[RuboCop](https://github.com/rubocop-hq/rubocop). RuboCop runs as part of the
+To lint Ruby sources, Focaccia uses [RuboCop]. RuboCop runs as part of the
 `lint` task. To run RuboCop by itself, invoke the `lint:rubocop` task.
 
 ```console
@@ -116,7 +110,7 @@ $ bundle exec rake lint:rubocop
 ### Node.js
 
 Node.js is an optional dependency that is used for formatting text sources with
-[prettier](https://prettier.io/).
+[prettier].
 
 Node.js is only required for formatting if modifying the following filetypes:
 
@@ -124,11 +118,9 @@ Node.js is only required for formatting if modifying the following filetypes:
 - `yaml`
 - `yml`
 
-You will need to install
-[Node.js](https://nodejs.org/en/download/package-manager/).
+You will need to install [Node.js].
 
-On macOS, you can install Node.js with
-[Homebrew](https://docs.brew.sh/Installation):
+On macOS, you can install Node.js with [Homebrew]:
 
 ```sh
 brew install node
@@ -144,9 +136,8 @@ rake lint
 
 ## Testing
 
-A PR must have new or existing tests for it to be merged. The
-[Rust book chapter on testing](https://doc.rust-lang.org/book/ch11-00-testing.html)
-is a good place to start.
+A PR must have new or existing tests for it to be merged. The [Rust book chapter
+on testing] is a good place to start.
 
 To run tests:
 
@@ -170,12 +161,33 @@ Tests are run for every PR. All builds must pass before merging a PR.
 Version specifiers in `Cargo.toml` are NPM caret-style by default. A version
 specifier of `4.1.2` means `4.1.2 <= version < 5.0.0`.
 
-To see what crates are outdated, you can use
-[cargo-outdated](https://github.com/kbknapp/cargo-outdated).
+To see what crates are outdated, you can use [cargo-outdated].
 
 If you need to pull in an updated version of a crate for a bugfix or a new
 feature, update the version number in `Cargo.toml`. See
-[Artichoke GH-548](https://github.com/artichoke/artichoke/pull/548) for an
-example.
+[artichoke/artichoke#548] for an example.
 
-Regular dependency bumps are handled by [@dependabot](https://dependabot.com/).
+Regular dependency bumps are handled by [@dependabot].
+
+[artichoke]: https://github.com/artichoke
+[there is lots to do]: https://github.com/artichoke/artichoke/issues
+[`symbol`]: https://ruby-doc.org/core-2.6.3/Symbol.html
+[`string`]: https://ruby-doc.org/core-2.6.3/String.html
+[filed an issue so we can fix it]:
+  https://github.com/artichoke/artichoke/issues/new
+[file bugs specific to focaccia in this repository]:
+  https://github.com/artichoke/focaccia/issues/new
+[good first issues are labeled `e-easy`]:
+  https://github.com/artichoke/focaccia/labels/E-easy
+[join artichoke's public discord server]: https://discord.gg/QCe2tp2
+[rustup]: https://rustup.rs/
+[homebrew]: https://docs.brew.sh/Installation
+[bundler]: https://bundler.io/
+[rubocop]: https://github.com/rubocop-hq/rubocop
+[prettier]: https://prettier.io/
+[node.js]: https://nodejs.org/en/download/package-manager/
+[rust book chapter on testing]:
+  https://doc.rust-lang.org/book/ch11-00-testing.html
+[cargo-outdated]: https://github.com/kbknapp/cargo-outdated
+[artichoke/artichoke#548]: https://github.com/artichoke/artichoke/pull/548
+[@dependabot]: https://dependabot.com/


### PR DESCRIPTION
Moving links to named anchors at the bottom of the document makes the
raw markdown format nicer and read easier.