### PR TITLE
Require version-sync at least 0.9.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ std = []
 [dev-dependencies]
 # Check that crate versions are properly updated in documentation and code when
 # bumping the version.
-version-sync = "0.9"
+version-sync = "0.9, >= 0.9.2"


### PR DESCRIPTION
This fixes some warnings on current nightly related to panic formatting.