### PR TITLE
Add additional crate metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "focaccia"
-version = "1.0.1"
+version = "1.0.2" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
-edition = "2018"
-description = "no_std implementation of Unicode case folding comparisons"
-repository = "https://github.com/artichoke/focaccia"
-readme = "README.md"
 license = "MIT"
+edition = "2018"
+readme = "README.md"
+repository = "https://github.com/artichoke/focaccia"
+documentation = "https://docs.rs/focaccia"
+homepage = "https://github.com/artichoke/focaccia"
+description = "no_std implementation of Unicode case folding comparisons"
 keywords = ["case-folding", "case-insensitive", "case", "no_std", "unicode"]
 categories = ["internationalization", "no-std", "text-processing"]
 include = ["src/**/*", "tests/**/*", "CaseFolding.txt", "LICENSE", "README.md"]

--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ namespace :lint do
     FileList['**/{build,lib,main}.rs'].each do |root|
       FileUtils.touch(root)
     end
-    sh 'cargo clippy --workspace --all-features'
+    sh 'cargo clippy --workspace --all-features --all-targets'
   end
 
   desc 'Lint Rust sources with Clippy restriction pass (unenforced lints)'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! Focaccia supports full, ASCII, and Turkic [Unicode case folding] equality
 //! and [`Ordering`] comparisons.
 //!
-//! The primary entrypoint to Focaccia is the [`CaseFold`] enum. Focaccia also
+//! The primary entry point to Focaccia is the [`CaseFold`] enum. Focaccia also
 //! provides free functions for each case folding scheme.
 //!
 //! # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@
 //! [`Error`]: https://doc.rust-lang.org/stable/std/error/trait.Error.html
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/focaccia/1.0.1")]
+#![doc(html_root_url = "https://docs.rs/focaccia/1.0.2")]
 
 // Ensure code blocks in README.md compile
 #[cfg(doctest)]


### PR DESCRIPTION
Bump version to prep for 1.0.2 release.

Update Rakefile to add `--all-targets` to clippy invocation to match CI.