### PR TITLE
Release v1.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focaccia"
-version = "1.1.1" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.1.2" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@
 //! [`Error`]: https://doc.rust-lang.org/stable/std/error/trait.Error.html
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/focaccia/1.1.1")]
+#![doc(html_root_url = "https://docs.rs/focaccia/1.1.2")]
 
 // Ensure code blocks in README.md compile
 #[cfg(doctest)]


### PR DESCRIPTION
Release `focaccia` 1.1.2.

[`focaccia` is published on crates.io](https://crates.io/crates/focaccia/1.1.2).

This release improves code quality and documentation.

## Improvements

- Rename inner 'eq' case folding functions to 'case_eq' https://github.com/artichoke/focaccia/pull/110
- Remove `matches!` macros in test and doc assertions https://github.com/artichoke/focaccia/pull/111