### PR TITLE
Add more case folding vector tests to crate root and tests for pathological cases

### DIFF
--- a/src/folding/ascii.rs
+++ b/src/folding/ascii.rs
@@ -39,8 +39,21 @@ pub fn case_eq(left: &[u8], right: &[u8]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{case_eq, casecmp};
     use core::cmp::Ordering;
+
+    use super::{case_eq, casecmp};
+
+    #[test]
+    fn empty_string() {
+        assert!(case_eq(b"", b""));
+        assert_eq!(casecmp(b"", b""), Ordering::Equal);
+
+        assert!(!case_eq(b"", b"rake"));
+        assert_eq!(casecmp(b"", b"rake"), Ordering::Less);
+
+        assert!(!case_eq(b"rake", b""));
+        assert_eq!(casecmp(b"rake", b""), Ordering::Greater);
+    }
 
     #[test]
     fn compares_symbols_without_regard_to_case() {

--- a/src/folding/ascii.rs
+++ b/src/folding/ascii.rs
@@ -56,6 +56,24 @@ mod tests {
     }
 
     #[test]
+    fn unicode_replacement_character() {
+        assert!(case_eq("\u{FFFD}".as_bytes(), "\u{FFFD}".as_bytes()));
+        assert_eq!(
+            casecmp("\u{FFFD}".as_bytes(), "\u{FFFD}".as_bytes()),
+            Ordering::Equal
+        );
+
+        assert_eq!(
+            casecmp("\u{FFFD}".as_bytes(), "\u{FFFD}yam".as_bytes()),
+            Ordering::Less
+        );
+        assert_eq!(
+            casecmp("\u{FFFD}yam".as_bytes(), "\u{FFFD}".as_bytes()),
+            Ordering::Greater
+        );
+    }
+
+    #[test]
     fn compares_symbols_without_regard_to_case() {
         assert!(!case_eq(b"abcdef", b"abcde"));
         assert!(case_eq(b"aBcDeF", b"abcdef"));

--- a/src/folding/full.rs
+++ b/src/folding/full.rs
@@ -45,8 +45,27 @@ pub fn case_eq(left: &str, right: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{case_eq, casecmp};
     use core::cmp::Ordering;
+
+    use super::{case_eq, casecmp};
+
+    #[test]
+    fn empty_string() {
+        assert!(case_eq("", ""));
+        assert_eq!(casecmp("", ""), Ordering::Equal);
+
+        assert!(!case_eq("", "rake"));
+        assert_eq!(casecmp("", "rake"), Ordering::Less);
+
+        assert!(!case_eq("rake", ""));
+        assert_eq!(casecmp("rake", ""), Ordering::Greater);
+
+        assert!(!case_eq("", "São Paulo"));
+        assert_eq!(casecmp("", "São Paulo"), Ordering::Less);
+
+        assert!(!case_eq("São Paulo", ""));
+        assert_eq!(casecmp("São Paulo", ""), Ordering::Greater);
+    }
 
     #[test]
     fn compares_symbols_without_regard_to_case() {

--- a/src/folding/full.rs
+++ b/src/folding/full.rs
@@ -68,6 +68,15 @@ mod tests {
     }
 
     #[test]
+    fn unicode_replacement_character() {
+        assert!(case_eq("\u{FFFD}", "\u{FFFD}"));
+        assert_eq!(casecmp("\u{FFFD}", "\u{FFFD}"), Ordering::Equal);
+
+        assert_eq!(casecmp("\u{FFFD}", "\u{FFFD}yam"), Ordering::Less);
+        assert_eq!(casecmp("\u{FFFD}yam", "\u{FFFD}"), Ordering::Greater);
+    }
+
+    #[test]
     fn compares_symbols_without_regard_to_case() {
         assert!(!case_eq("abcdef", "abcde"));
         assert!(case_eq("aBcDeF", "abcdef"));

--- a/src/folding/turkic.rs
+++ b/src/folding/turkic.rs
@@ -67,8 +67,33 @@ pub fn case_eq(left: &str, right: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{case_eq, casecmp};
     use core::cmp::Ordering;
+
+    use super::{case_eq, casecmp};
+
+    #[test]
+    fn empty_string() {
+        assert!(case_eq("", ""));
+        assert_eq!(casecmp("", ""), Ordering::Equal);
+
+        assert!(!case_eq("", "rake"));
+        assert_eq!(casecmp("", "rake"), Ordering::Less);
+
+        assert!(!case_eq("rake", ""));
+        assert_eq!(casecmp("rake", ""), Ordering::Greater);
+
+        assert!(!case_eq("", "São Paulo"));
+        assert_eq!(casecmp("", "São Paulo"), Ordering::Less);
+
+        assert!(!case_eq("São Paulo", ""));
+        assert_eq!(casecmp("São Paulo", ""), Ordering::Greater);
+
+        assert!(!case_eq("", "İstanbul"));
+        assert_eq!(casecmp("", "İstanbul"), Ordering::Less);
+
+        assert!(!case_eq("İstanbul", ""));
+        assert_eq!(casecmp("İstanbul", ""), Ordering::Greater);
+    }
 
     #[test]
     fn compares_symbols_without_regard_to_case() {

--- a/src/folding/turkic.rs
+++ b/src/folding/turkic.rs
@@ -96,6 +96,15 @@ mod tests {
     }
 
     #[test]
+    fn unicode_replacement_character() {
+        assert!(case_eq("\u{FFFD}", "\u{FFFD}"));
+        assert_eq!(casecmp("\u{FFFD}", "\u{FFFD}"), Ordering::Equal);
+
+        assert_eq!(casecmp("\u{FFFD}", "\u{FFFD}yam"), Ordering::Less);
+        assert_eq!(casecmp("\u{FFFD}yam", "\u{FFFD}"), Ordering::Greater);
+    }
+
+    #[test]
     fn compares_symbols_without_regard_to_case() {
         assert!(!case_eq("abcdef", "abcde"));
         assert!(case_eq("aBcDeF", "abcdef"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,36 +429,84 @@ impl TryFrom<Option<&[u8]>> for CaseFold {
 // Tests using IDN case folding test vectors:
 #[cfg(test)]
 mod tests {
+    use core::cmp::Ordering;
+
     use crate::CaseFold;
 
     // https://tools.ietf.org/html/draft-josefsson-idn-test-vectors-00#section-4.2
     #[test]
-    fn case_folding_ascii() {
+    fn case_folding_ascii_case_eq() {
         let input = "CAFE";
         let output = "cafe";
+
         assert!(CaseFold::Full.case_eq(input, output));
         assert!(CaseFold::Full.case_eq(output, input));
+
         assert!(CaseFold::Ascii.case_eq(input, output));
         assert!(CaseFold::Ascii.case_eq(output, input));
+
         assert!(CaseFold::Turkic.case_eq(input, output));
         assert!(CaseFold::Turkic.case_eq(output, input));
+
+        assert!(CaseFold::Lithuanian.case_eq(input, output));
+        assert!(CaseFold::Lithuanian.case_eq(output, input));
+    }
+
+    // https://tools.ietf.org/html/draft-josefsson-idn-test-vectors-00#section-4.2
+    #[test]
+    fn case_folding_ascii_casecmp() {
+        let input = "CAFE";
+        let output = "cafe";
+
+        assert_eq!(CaseFold::Full.casecmp(input, output), Ordering::Equal);
+        assert_eq!(CaseFold::Full.casecmp(output, input), Ordering::Equal);
+
+        assert_eq!(CaseFold::Ascii.casecmp(input, output), Ordering::Equal);
+        assert_eq!(CaseFold::Ascii.casecmp(output, input), Ordering::Equal);
+
+        assert_eq!(CaseFold::Turkic.casecmp(input, output), Ordering::Equal);
+        assert_eq!(CaseFold::Turkic.casecmp(output, input), Ordering::Equal);
+
+        assert_eq!(CaseFold::Lithuanian.casecmp(input, output), Ordering::Equal);
+        assert_eq!(CaseFold::Lithuanian.casecmp(output, input), Ordering::Equal);
+    }
+
+    // https://tools.ietf.org/html/draft-josefsson-idn-test-vectors-00#section-4.3
+    #[test]
+    fn case_folding_8bit_case_eq() {
+        let input = "ß";
+        let output = "ss";
+
+        assert!(CaseFold::Full.case_eq(input, output));
+        assert!(CaseFold::Full.case_eq(output, input));
+
+        assert!(!CaseFold::Ascii.case_eq(input, output));
+        assert!(!CaseFold::Ascii.case_eq(output, input));
+
+        assert!(CaseFold::Turkic.case_eq(input, output));
+        assert!(CaseFold::Turkic.case_eq(output, input));
+
         assert!(CaseFold::Lithuanian.case_eq(input, output));
         assert!(CaseFold::Lithuanian.case_eq(output, input));
     }
 
     // https://tools.ietf.org/html/draft-josefsson-idn-test-vectors-00#section-4.3
     #[test]
-    fn case_folding_8bit() {
+    fn case_folding_8bit_casecmp() {
         let input = "ß";
         let output = "ss";
-        assert!(CaseFold::Full.case_eq(input, output));
-        assert!(CaseFold::Full.case_eq(output, input));
-        assert!(!CaseFold::Ascii.case_eq(input, output));
-        assert!(!CaseFold::Ascii.case_eq(output, input));
-        assert!(CaseFold::Turkic.case_eq(input, output));
-        assert!(CaseFold::Turkic.case_eq(output, input));
-        assert!(CaseFold::Lithuanian.case_eq(input, output));
-        assert!(CaseFold::Lithuanian.case_eq(output, input));
+
+        assert_eq!(CaseFold::Full.casecmp(input, output), Ordering::Equal);
+        assert_eq!(CaseFold::Full.casecmp(output, input), Ordering::Equal);
+
+        assert_ne!(CaseFold::Ascii.casecmp(input, output), Ordering::Equal);
+        assert_ne!(CaseFold::Ascii.casecmp(output, input), Ordering::Equal);
+
+        assert_eq!(CaseFold::Turkic.casecmp(input, output), Ordering::Equal);
+        assert_eq!(CaseFold::Turkic.casecmp(output, input), Ordering::Equal);
+
+        assert_eq!(CaseFold::Lithuanian.casecmp(input, output), Ordering::Equal);
+        assert_eq!(CaseFold::Lithuanian.casecmp(output, input), Ordering::Equal);
     }
 
     // https://tools.ietf.org/html/draft-josefsson-idn-test-vectors-00#section-4.4
@@ -466,43 +514,95 @@ mod tests {
     fn case_folding_turkic_capital_i_with_dot() {
         let input = "İ";
         let output = "i";
+
         assert!(CaseFold::Turkic.case_eq(input, output));
         assert!(CaseFold::Turkic.case_eq(output, input));
+
+        assert_eq!(CaseFold::Turkic.casecmp(input, output), Ordering::Equal);
+        assert_eq!(CaseFold::Turkic.casecmp(output, input), Ordering::Equal);
     }
 
     // https://tools.ietf.org/html/draft-josefsson-idn-test-vectors-00#section-4.5
     //
     // Multibyte folding is not supported.
     #[test]
-    #[should_panic]
-    fn case_folding_multibyte() {
+    fn case_folding_multibyte_case_eq() {
         let input = "Ńͺ";
         let output = "ń ι";
-        assert!(CaseFold::Full.case_eq(input, output));
-        assert!(CaseFold::Full.case_eq(output, input));
+
+        assert!(!CaseFold::Full.case_eq(input, output));
+        assert!(!CaseFold::Full.case_eq(output, input));
+
         assert!(!CaseFold::Ascii.case_eq(input, output));
         assert!(!CaseFold::Ascii.case_eq(output, input));
-        assert!(CaseFold::Turkic.case_eq(input, output));
-        assert!(CaseFold::Turkic.case_eq(output, input));
-        assert!(CaseFold::Lithuanian.case_eq(input, output));
-        assert!(CaseFold::Lithuanian.case_eq(output, input));
+
+        assert!(!CaseFold::Turkic.case_eq(input, output));
+        assert!(!CaseFold::Turkic.case_eq(output, input));
+
+        assert!(!CaseFold::Lithuanian.case_eq(input, output));
+        assert!(!CaseFold::Lithuanian.case_eq(output, input));
+    }
+
+    // https://tools.ietf.org/html/draft-josefsson-idn-test-vectors-00#section-4.5
+    //
+    // Multibyte folding is not supported.
+    #[test]
+    fn case_folding_multibyte_casecmp() {
+        let input = "Ńͺ";
+        let output = "ń ι";
+
+        assert_ne!(CaseFold::Full.casecmp(input, output), Ordering::Equal);
+        assert_ne!(CaseFold::Full.casecmp(output, input), Ordering::Equal);
+
+        assert_ne!(CaseFold::Ascii.casecmp(input, output), Ordering::Equal);
+        assert_ne!(CaseFold::Ascii.casecmp(output, input), Ordering::Equal);
+
+        assert_ne!(CaseFold::Turkic.casecmp(input, output), Ordering::Equal);
+        assert_ne!(CaseFold::Turkic.casecmp(output, input), Ordering::Equal);
+
+        assert_ne!(CaseFold::Lithuanian.casecmp(input, output), Ordering::Equal);
+        assert_ne!(CaseFold::Lithuanian.casecmp(output, input), Ordering::Equal);
     }
 
     // https://tools.ietf.org/html/draft-josefsson-idn-test-vectors-00#section-4.6
     //
     // These folding operations are not supported.
     #[test]
-    #[should_panic]
-    fn case_folding() {
+    fn case_folding_4_6_case_eq() {
         let input = "℡㏆𝞻";
         let output = "telc∕kgσ";
-        assert!(CaseFold::Full.case_eq(input, output));
-        assert!(CaseFold::Full.case_eq(output, input));
+
+        assert!(!CaseFold::Full.case_eq(input, output));
+        assert!(!CaseFold::Full.case_eq(output, input));
+
         assert!(!CaseFold::Ascii.case_eq(input, output));
         assert!(!CaseFold::Ascii.case_eq(output, input));
-        assert!(CaseFold::Turkic.case_eq(input, output));
-        assert!(CaseFold::Turkic.case_eq(output, input));
-        assert!(CaseFold::Lithuanian.case_eq(input, output));
-        assert!(CaseFold::Lithuanian.case_eq(output, input));
+
+        assert!(!CaseFold::Turkic.case_eq(input, output));
+        assert!(!CaseFold::Turkic.case_eq(output, input));
+
+        assert!(!CaseFold::Lithuanian.case_eq(input, output));
+        assert!(!CaseFold::Lithuanian.case_eq(output, input));
+    }
+
+    // https://tools.ietf.org/html/draft-josefsson-idn-test-vectors-00#section-4.6
+    //
+    // These folding operations are not supported.
+    #[test]
+    fn case_folding_4_6_casecmp() {
+        let input = "℡㏆𝞻";
+        let output = "telc∕kgσ";
+
+        assert_ne!(CaseFold::Full.casecmp(input, output), Ordering::Equal);
+        assert_ne!(CaseFold::Full.casecmp(output, input), Ordering::Equal);
+
+        assert_ne!(CaseFold::Ascii.casecmp(input, output), Ordering::Equal);
+        assert_ne!(CaseFold::Ascii.casecmp(output, input), Ordering::Equal);
+
+        assert_ne!(CaseFold::Turkic.casecmp(input, output), Ordering::Equal);
+        assert_ne!(CaseFold::Turkic.casecmp(output, input), Ordering::Equal);
+
+        assert_ne!(CaseFold::Lithuanian.casecmp(input, output), Ordering::Equal);
+        assert_ne!(CaseFold::Lithuanian.casecmp(output, input), Ordering::Equal);
     }
 }


### PR DESCRIPTION
- Add tests for casecmp.
- Change should_panic tests to properly assert that the folding mode is not supported.
- Add tests for casecmp and case_eq with empty strings.
- Add tests for casecmp and case_eq with strings containing the Unicode replacement character.