### PR TITLE
Ensure crate abides by the Unicode Data Files and Software License

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "focaccia"
 version = "1.1.2" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
-license = "MIT"
+license = "MIT AND Unicode-DFS-2016"
 edition = "2018"
 readme = "README.md"
 repository = "https://github.com/artichoke/focaccia"
@@ -11,7 +11,7 @@ homepage = "https://github.com/artichoke/focaccia"
 description = "no_std implementation of Unicode case folding comparisons"
 keywords = ["case-folding", "case-insensitive", "case", "no_std", "unicode"]
 categories = ["internationalization", "no-std", "text-processing"]
-include = ["src/**/*", "tests/**/*", "CaseFolding.txt", "LICENSE", "README.md"]
+include = ["src/**/*", "tests/**/*", "CaseFolding.txt", "LICENSE", "LICENSE-UNICODE", "README.md"]
 
 [features]
 default = ["std"]

--- a/LICENSE-UNICODE
+++ b/LICENSE-UNICODE
@@ -1,0 +1,46 @@
+UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE
+
+See Terms of Use <https://www.unicode.org/copyright.html>
+for definitions of Unicode Inc.’s Data Files and Software.
+
+NOTICE TO USER: Carefully read the following legal agreement.
+BY DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING UNICODE INC.'S
+DATA FILES ("DATA FILES"), AND/OR SOFTWARE ("SOFTWARE"),
+YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT.
+IF YOU DO NOT AGREE, DO NOT DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE
+THE DATA FILES OR SOFTWARE.
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 1991-2022 Unicode, Inc. All rights reserved.
+Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Unicode data files and any associated documentation
+(the "Data Files") or Unicode software and any associated documentation
+(the "Software") to deal in the Data Files or Software
+without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, and/or sell copies of
+the Data Files or Software, and to permit persons to whom the Data Files
+or Software are furnished to do so, provided that either
+(a) this copyright and permission notice appear with all copies
+of the Data Files or Software, or
+(b) this copyright and permission notice appear in associated
+Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder
+shall not be used in advertising or otherwise to promote the sale,
+use or other dealings in these Data Files or Software without prior
+written authorization of the copyright holder.

--- a/README.md
+++ b/README.md
@@ -139,3 +139,18 @@ rules will be accompanied with a minor version bump.
 ## License
 
 `focaccia` is licensed under the [MIT License](LICENSE) (c) Ryan Lopopolo.
+
+`focaccia` includes Unicode Data Files which are subject to the [Unicode Terms
+of Use] and [Unicode Data Files and Software License](LICENSE-UNICODE) (c)
+1991-2022 Unicode, Inc.
+
+[unicode terms of use]: https://www.unicode.org/copyright.html
+
+Generated files in this repository are marked with `// @generated` comments and
+the Unicode copyright. These generated files incorporate data derived from the
+Unicode Data Files. More details about the generation process can be found in
+[`scripts/gen_case_lookups.rb`]. The generated sources created by this script
+are subject to both the MIT License contained in this repository and the Unicode
+Data Files and Software License.
+
+[`scripts/gen_case_lookups.rb`]: scripts/gen_case_lookups.rb

--- a/Rakefile
+++ b/Rakefile
@@ -95,8 +95,41 @@ namespace :unicode do
     ruby 'scripts/gen_case_lookups.rb'
   end
 
+  # Per the Unicode Terms of Use -- https://www.unicode.org/copyright.html --
+  # data found under `https://www.unicode.org/Public/` are considered Unicode
+  # Data Files and are subject to these constaints:
+  #
+  # 1. Certain documents and files on this website contain a legend indicating
+  #    that "Modification is permitted." Any person is hereby authorized,
+  #    without fee, to modify such documents and files to create derivative
+  #    works conforming to the Unicode® Standard, subject to Terms and
+  #    Conditions herein.
+  # 2. Any person is hereby authorized, without fee, to view, use, reproduce,
+  #    and distribute all documents and files, subject to the Terms and
+  #    Conditions herein.
+  # 3. Further specifications of rights and restrictions pertaining to the use
+  #    of the Unicode DATA FILES and SOFTWARE can be found in the Unicode Data
+  #    Files and Software License.
+  #
+  # The Unicode Data Files and Software License, which can be found at
+  # <https://www.unicode.org/license.txt> is included in this repository. The
+  # license requires one of:
+  #
+  # (a) this copyright and permission notice appear with all copies of the
+  #     Data Files or Software, or
+  # (b) this copyright and permission notice appear in associated Documentation.
+  #
+  # `focaccia` distributes this license as `LICENSE-UNICODE` in crate bundles
+  # and includes `AND Unicode-DFS-2016` in the `Cargo.toml` SPDX license
+  # expression. See: https://spdx.org/licenses/Unicode-DFS-2016.html.
+  #
+  # Updates to Unicode Data Files performed by this `rake` task also update the
+  # embedded license.
   desc 'Update Unicode data'
   task :update do
+    URI.parse('https://www.unicode.org/license.txt').open do |data|
+      IO.copy_stream(data, 'LICENSE-UNICODE')
+    end
     URI.parse('https://www.unicode.org/Public/UCD/latest/ucd/CaseFolding.txt').open do |data|
       IO.copy_stream(data, 'CaseFolding.txt')
     end

--- a/scripts/gen_case_lookups.rb
+++ b/scripts/gen_case_lookups.rb
@@ -1,6 +1,37 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# Create lookup tables and tests for Unicode Case Folding transformations using
+# the `CaseFolding.txt` Unicode Data File, which is subject to these constraints:
+#
+# 1. Certain documents and files on this website contain a legend indicating
+#    that "Modification is permitted." Any person is hereby authorized,
+#    without fee, to modify such documents and files to create derivative
+#    works conforming to the Unicode® Standard, subject to Terms and
+#    Conditions herein.
+# 2. Any person is hereby authorized, without fee, to view, use, reproduce,
+#    and distribute all documents and files, subject to the Terms and
+#    Conditions herein.
+# 3. Further specifications of rights and restrictions pertaining to the use
+#    of the Unicode DATA FILES and SOFTWARE can be found in the Unicode Data
+#    Files and Software License.
+#
+# The Unicode Data Files and Software License, which can be found at
+# <https://www.unicode.org/license.txt> is included in this repository. The
+# license requires one of:
+#
+# (a) this copyright and permission notice appear with all copies of the
+#     Data Files or Software, or
+# (b) this copyright and permission notice appear in associated Documentation.
+#
+# `focaccia` distributes this license as `LICENSE-UNICODE` in crate bundles
+# and includes `AND Unicode-DFS-2016` in the `Cargo.toml` SPDX license
+# expression. See: https://spdx.org/licenses/Unicode-DFS-2016.html.
+#
+# The generated sources created by this script are subject to both the MIT
+# License contained in this repository, `LICENSE`, and the Unicode Data Files
+# and Software License, `LICENSE-UNICODE`.
+
 mappings = File.readlines('CaseFolding.txt')
 
 casefolding_version = mappings[0..2].map { |line| "// #{line.delete_prefix('# ')}" }.join.chomp


### PR DESCRIPTION
Update the SPDX license expression in `Cargo.toml` to be `MIT AND Unicode-DFS-2016` to reflect the inclusion of `CaseFolding.txt` and the generated Rust sources that are derived from it.

Embed a copy of https://www.unicode.org/license.txt in the repository as `LICENSE-UNICODE` and distribute this license in crates.io bundles.

Update the License section in `README.md` and add explainer text to the rake task for fetching the Unicode Data Files and the script that generates source from the Unicode Data Files.

When updating the `CaseFolding.txt` data file with `rake unicode:update`, also fetch the license from https://www.unicode.org/license.txt.