### PR TITLE
Prepare for 1.2.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focaccia"
-version = "1.1.2" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.2.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT AND Unicode-DFS-2016"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-focaccia = "1.1.2"
+focaccia = "1.2.0"
 ```
 
 Then make case insensitive string comparisons like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@
 //! [`Error`]: https://doc.rust-lang.org/stable/std/error/trait.Error.html
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/focaccia/1.1.2")]
+#![doc(html_root_url = "https://docs.rs/focaccia/1.2.0")]
 
 // Ensure code blocks in README.md compile
 #[cfg(doctest)]


### PR DESCRIPTION
Release `focaccia` 1.2.0.

[`focaccia` is published on crates.io](https://crates.io/crates/focaccia/1.2.0).

This release improves code quality, testing, and packaging.

**NOTE**: `focaccia`'s license has been updated to properly reflect its usage of Unicode Data Files. The SPDX expression for this crate is now `MIT AND Unicode-DFS-2016`. https://github.com/artichoke/focaccia/pull/149

## Improvements

- Remove dead trait impls in mapping modules to slightly improve compile times. https://github.com/artichoke/focaccia/pull/113
- Use unchecked arithmetic in lookup function. https://github.com/artichoke/focaccia/pull/115
- Use `..` to destructure enums when we do not care about their contents. https://github.com/artichoke/focaccia/pull/135

## Testing improvements

- Fix exhaustive tests to start at NUL instead of '0'. https://github.com/artichoke/focaccia/pull/114
- Add more case folding vector tests to crate root and tests for pathological cases. https://github.com/artichoke/focaccia/pull/116
- Fix typo in test name, rename to clarify what it tests. https://github.com/artichoke/focaccia/pull/127
- Add test that `impl Display for NoSuchCaseFoldingScheme` is non-empty. https://github.com/artichoke/focaccia/pull/146

## Packaging improvements

- Use precise crate version in Cargo.toml snippet in README. https://github.com/artichoke/focaccia/pull/124
- Ensure crate abides by the Unicode Data Files and Software License. https://github.com/artichoke/focaccia/pull/149