### PR TITLE
Fix a bug that prevented an exhasutive test from using full ASCII range

### DIFF
--- a/src/folding/ascii.rs
+++ b/src/folding/ascii.rs
@@ -206,8 +206,8 @@ mod tests {
 
     #[test]
     fn exhaustive() {
-        let lower = 'a'..'z';
-        let upper = 'A'..'Z';
+        let lower = 'a'..='z';
+        let upper = 'A'..='Z';
         let mut l_buf = [0; 4];
         let mut r_buf = [0; 4];
         for (left, right) in lower.zip(upper) {


### PR DESCRIPTION
Caught by `clippy::almost_complete_letter_range` which is new in the
latest 1.63.0 stable.

```
warning: almost complete ascii letter range
   --> src/folding/ascii.rs:209:21
    |
209 |         let lower = 'a'..'z';
    |                     ^^^--^^^
    |                        |
    |                        help: use an inclusive range: `..=`
    |
note: the lint level is defined here
   --> src/lib.rs:1:9
    |
1   | #![warn(clippy::all)]
    |         ^^^^^^^^^^^
    = note: `#[warn(clippy::almost_complete_letter_range)]` implied by `#[warn(clippy::all)]`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#almost_complete_letter_range

warning: almost complete ascii letter range
   --> src/folding/ascii.rs:210:21
    |
210 |         let upper = 'A'..'Z';
    |                     ^^^--^^^
    |                        |
    |                        help: use an inclusive range: `..=`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#almost_complete_letter_range
```