### PR TITLE
Prepare for release v1.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focaccia"
-version = "1.3.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.3.1" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT AND Unicode-DFS-2016"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-focaccia = "1.3.0"
+focaccia = "1.3.1"
 ```
 
 Then make case insensitive string comparisons like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@
 //! [`Error`]: https://doc.rust-lang.org/stable/std/error/trait.Error.html
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/focaccia/1.3.0")]
+#![doc(html_root_url = "https://docs.rs/focaccia/1.3.1")]
 
 #[cfg(feature = "std")]
 extern crate std;


### PR DESCRIPTION
Release `focaccia` 1.3.1.

[`focaccia` is published on crates.io](https://crates.io/crates/focaccia/1.3.1).

This release improves code quality and documentation.

## Improvements

- Add additional tests to achieve 100% code coverage. https://github.com/artichoke/focaccia/pull/165
- Add cargo-spellcheck config and fix typos. https://github.com/artichoke/focaccia/pull/166