### PR TITLE
Set `rust-version` in `Cargo.toml` to 1.52.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.3.1" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT AND Unicode-DFS-2016"
 edition = "2018"
+rust-version = "1.52.0"
 readme = "README.md"
 repository = "https://github.com/artichoke/focaccia"
 documentation = "https://docs.rs/focaccia"


### PR DESCRIPTION
This allows clippy to detect this crate's MSRV so the `clippy::uninlined_format_args` does not trigger.