### PR TITLE
Remove dependency on actions-rs organization GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,10 +25,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/build-and-test@v1
         with:
           toolchain: stable
-          profile: minimal
 
       - name: Compile
         run: cargo build --verbose
@@ -57,11 +56,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/build-and-test@v1
         with:
           toolchain: "1.52.0"
-          profile: minimal
-          override: true
 
       - name: Compile
         run: cargo build --verbose
@@ -89,20 +86,15 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/lint-and-format@v1
         with:
           toolchain: stable
-          profile: minimal
-          components: rustfmt, clippy
 
       - name: Check formatting
-        run: cargo fmt -- --check --color=auto
+        run: cargo fmt --check
 
       - name: Lint with Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets
+        run: cargo clippy --workspace --all-features --all-targets
 
   ruby:
     name: Lint and format Ruby


### PR DESCRIPTION
These actions are unmaintained and use deprecated GitHub Actions technologies.

See: https://github.com/artichoke/project-infrastructure/issues/265