### PR TITLE
Add no-std, no-alloc crates.io category metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focaccia"
-version = "1.3.1" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.3.2" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT AND Unicode-DFS-2016"
 edition = "2018"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/focaccia"
 homepage = "https://github.com/artichoke/focaccia"
 description = "no_std implementation of Unicode case folding comparisons"
 keywords = ["case-folding", "case-insensitive", "case", "no_std", "unicode"]
-categories = ["internationalization", "no-std", "text-processing"]
+categories = ["internationalization", "no-std", "no-std::no-alloc", "text-processing"]
 include = ["src/**/*", "tests/**/*", "CaseFolding.txt", "LICENSE", "LICENSE-UNICODE", "README.md"]
 
 [features]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-focaccia = "1.3.1"
+focaccia = "1.3.2"
 ```
 
 Then make case insensitive string comparisons like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@
 //! [`Error`]: https://doc.rust-lang.org/stable/std/error/trait.Error.html
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/focaccia/1.3.1")]
+#![doc(html_root_url = "https://docs.rs/focaccia/1.3.2")]
 
 #[cfg(feature = "std")]
 extern crate std;


### PR DESCRIPTION
Prepare for v1.3.2 release.