### PR TITLE
Update MSRV to 1.56.0 and prepare for v1.4.0 release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Install Rust toolchain
         uses: artichoke/setup-rust/build-and-test@v1.10.0
         with:
-          toolchain: "1.52.0"
+          toolchain: "1.56.0"
 
       - name: Compile
         run: cargo build --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "focaccia"
-version = "1.3.2" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.4.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT AND Unicode-DFS-2016"
-edition = "2018"
-rust-version = "1.52.0"
+edition = "2021"
+rust-version = "1.56.0"
 readme = "README.md"
 repository = "https://github.com/artichoke/focaccia"
 documentation = "https://docs.rs/focaccia"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-focaccia = "1.3.2"
+focaccia = "1.4.0"
 ```
 
 Then make case insensitive string comparisons like:
@@ -125,7 +125,7 @@ All features are enabled by default.
 
 ### Minimum Supported Rust Version
 
-This crate requires at least Rust 1.52.0. This version can be bumped in minor
+This crate requires at least Rust 1.56.0. This version can be bumped in minor
 releases.
 
 ## Unicode Version

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@
 //! [`Error`]: https://doc.rust-lang.org/stable/std/error/trait.Error.html
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/focaccia/1.3.2")]
+#![doc(html_root_url = "https://docs.rs/focaccia/1.4.0")]
 
 #[cfg(feature = "std")]
 extern crate std;


### PR DESCRIPTION
CI is currently failing on trunk since the latest version of proc-macro2 (a transitive dep of a dev dependency) requires edition2021. 2021 edition is almost 2 years old, this seems like an acceptable shortcut to take.

Update focaccia to 2021 edition.